### PR TITLE
feat: update publishing scripts for kmarkdownp

### DIFF
--- a/publishingScripts/publishKMarkdownPJetbrains.sh
+++ b/publishingScripts/publishKMarkdownPJetbrains.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+./gradlew clean
+# To maven.henkle.dev
+./gradlew :kmarkdownp-parser-jetbrains:publishKotlinMultiplatformPublicationToMavenHenkleDevReleasesRepository
+./gradlew :kmarkdownp-parser-jetbrains:publishIosArm64PublicationToMavenHenkleDevReleasesRepository
+./gradlew :kmarkdownp-parser-jetbrains:publishIosSimulatorArm64PublicationToMavenHenkleDevReleasesRepository
+./gradlew :kmarkdownp-parser-jetbrains:publishAndroidReleasePublicationToMavenHenkleDevReleasesRepository
+## To GitHub Packages
+./gradlew :kmarkdownp-parser-jetbrains:publishKotlinMultiplatformPublicationToKMPBrowserGitHubPackagesRepository
+./gradlew :kmarkdownp-parser-jetbrains:publishIosArm64PublicationToKMPBrowserGitHubPackagesRepository
+./gradlew :kmarkdownp-parser-jetbrains:publishIosSimulatorArm64PublicationToKMPBrowserGitHubPackagesRepository
+./gradlew :kmarkdownp-parser-jetbrains:publishAndroidReleasePublicationToKMPBrowserGitHubPackagesRepository
+

--- a/publishingScripts/publishKMarkdownPTreesitter.sh
+++ b/publishingScripts/publishKMarkdownPTreesitter.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+./gradlew clean
+# To maven.henkle.dev
+./gradlew :kmarkdownp-parser-treesitter:publishKotlinMultiplatformPublicationToMavenHenkleDevReleasesRepository
+./gradlew :kmarkdownp-parser-treesitter:publishIosArm64PublicationToMavenHenkleDevReleasesRepository
+./gradlew :kmarkdownp-parser-treesitter:publishIosSimulatorArm64PublicationToMavenHenkleDevReleasesRepository
+./gradlew :kmarkdownp-parser-treesitter:publishAndroidReleasePublicationToMavenHenkleDevReleasesRepository
+# To GitHub Packages
+./gradlew :kmarkdownp-parser-treesitter:publishKotlinMultiplatformPublicationToKMPBrowserGitHubPackagesRepository
+./gradlew :kmarkdownp-parser-treesitter:publishIosArm64PublicationToKMPBrowserGitHubPackagesRepository
+./gradlew :kmarkdownp-parser-treesitter:publishIosSimulatorArm64PublicationToKMPBrowserGitHubPackagesRepository
+./gradlew :kmarkdownp-parser-treesitter:publishAndroidReleasePublicationToKMPBrowserGitHubPackagesRepository
+

--- a/publishingScripts/publishKMarkdownPUI.sh
+++ b/publishingScripts/publishKMarkdownPUI.sh
@@ -3,12 +3,10 @@
 # To maven.henkle.dev
 ./gradlew :kmarkdownp-ui:publishKotlinMultiplatformPublicationToMavenHenkleDevReleasesRepository
 ./gradlew :kmarkdownp-ui:publishIosArm64PublicationToMavenHenkleDevReleasesRepository
-./gradlew :kmarkdownp-ui:publishIosX64PublicationToMavenHenkleDevReleasesRepository
 ./gradlew :kmarkdownp-ui:publishIosSimulatorArm64PublicationToMavenHenkleDevReleasesRepository
 ./gradlew :kmarkdownp-ui:publishAndroidReleasePublicationToMavenHenkleDevReleasesRepository
 # To GitHub Packages
 ./gradlew :kmarkdownp-ui:publishKotlinMultiplatformPublicationToKMPBrowserGitHubPackagesRepository
 ./gradlew :kmarkdownp-ui:publishIosArm64PublicationToKMPBrowserGitHubPackagesRepository
-./gradlew :kmarkdownp-ui:publishIosX64PublicationToKMPBrowserGitHubPackagesRepository
 ./gradlew :kmarkdownp-ui:publishIosSimulatorArm64PublicationToKMPBrowserGitHubPackagesRepository
 ./gradlew :kmarkdownp-ui:publishAndroidReleasePublicationToKMPBrowserGitHubPackagesRepository


### PR DESCRIPTION
Changes:
- added new publishing scripts for the ktreesitter and jetbrains parser modules
- updated the existing kmarkdownp publishing script to remove the x86 iOS simulator target that was removed